### PR TITLE
Add initial mkdocs files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: build
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs
+      - run: mkdocs gh-deploy --force --clean --verbose
+        

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+site/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # luke-koekalastus
+
+## Ohjeistuksen kehittäminen ja testaaminen lokaalisti
+
+Dokumentaatiota voi muokata kloonaamalla tämän repositorion omalle koneelle ja muokkaamalla sen
+tiedostoja. Yksittäiset muokattavat dokumentaatio-sivut löytyvät docs-kansion alta. Tulosta voi tarkastella
+lokaalisti seuraavalla tavalla:
+- Asenna MkDocs: `pip install mkdocs`
+- Käynnistä serveri kansiossa, josta löytyy tiedosto `mkdocs.yml` komennolla `mkdocs serve`
+- Mene selaimella osoitteeseen `http://127.0.0.1:8000` (`localhost:8000`)
+- Tehtyjen muutosten jälkeen käännä dokumentaatio komennolla `mkdocs build`
+- Lisätietoja: [https://www.mkdocs.org/getting-started/](https://www.mkdocs.org/getting-started/)

--- a/docs/0_index.md
+++ b/docs/0_index.md
@@ -1,0 +1,3 @@
+# Tervetuloa LUKE:n koekalastuksen QField-kokeilun ohjesivuille!
+
+Tänne päivittyy ohjeistus piakkoin...

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Tervetuloa LUKE:n koekalastuksen QField-kokeilun ohjesivuille!
+
+Tänne päivittyy ohjeistus piakkoin...

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: LUKE-koekalastus
+site_url: https://github.com/GispoCoding/luke-koekalastus
+copyright: 'Tekijä: <a href="info@gispo.fi">Gispo Suomi Oy</a>'
+nav:  
+  - Koti: 0_index.md
+  
+use_directory_urls: false
+theme:
+  name: readthedocs


### PR DESCRIPTION
- PR sisältää peruskonfiguraation MkDocs-sivuston julkaisemiseksi  ([https://www.mkdocs.org/getting-started/#deploying](https://www.mkdocs.org/getting-started/#deploying))
- Sivuja ei vielä julkaistu, koska repo on asetettu privateksi, mutta se muuttamalla pitäisi toimia. Lisäinfoa  [https://www.mkdocs.org/user-guide/deploying-your-docs/#github-pages](https://www.mkdocs.org/user-guide/deploying-your-docs/#github-pages) tai katsomalla vastaavat asetukset esim. tuolta: https://github.com/GispoCoding/luke-qfield](https://github.com/GispoCoding/luke-qfield)